### PR TITLE
Mark run function as unsafe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ static VTABLE: RawWakerVTable = RawWakerVTable::new(
 );
 
 /// Run a `Future`.
-pub fn run<F: std::future::Future>(mut f: F) -> F::Output {
-    let mut f = unsafe { std::pin::Pin::new_unchecked(&mut f) };
+pub unsafe fn run<F: std::future::Future>(mut f: F) -> F::Output {
+    let mut f = std::pin::Pin::new_unchecked(&mut f);
     let park = Arc::new(Park::default());
     let sender = Arc::into_raw(park.clone());
     let raw_waker = RawWaker::new(sender as *const _, &VTABLE);

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -11,18 +11,20 @@ use std::{
 #[test]
 fn smoke() {
     let s = S(Arc::new(AtomicBool::new(false)));
-    extreme::run(async {});
-    extreme::run(async {
-        async {
-            s.await
-        }.await
-    });
-    extreme::run(async {
-        async {
+    unsafe {
+        extreme::run(async {});
+        extreme::run(async {
             async {
+                s.await
             }.await
-        }.await
-    });
+        });
+        extreme::run(async {
+            async {
+                async {
+                }.await
+            }.await
+        });
+    }
 }
 
 struct S(Arc<AtomicBool>);


### PR DESCRIPTION
https://github.com/spacejam/extreme/blob/74e2505a63c0e735fb2c03ad779c22f8267e71cf/src/lib.rs#L24-L44
Hi, the unsafe function(new_unchecked) called needs to ensure that the parameter must be:
[https://doc.rust-lang.org/std/pin/struct.Pin.html#method.new_unchecked](url)
- This constructor is unsafe because we cannot guarantee that the data pointed to by pointer is pinned, meaning that the data will not be moved or its storage invalidated until it gets dropped. If the constructed Pin\<P\> does not guarantee that the data P points to is pinned, that is a violation of the API contract and may lead to undefined behavior in later (safe) operations.

and the developer who calls the run function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.